### PR TITLE
Coordinates are floats in general - but you do know that.

### DIFF
--- a/dot2tex/dot2tex.py
+++ b/dot2tex/dot2tex.py
@@ -262,7 +262,7 @@ def parse_drawstring(drawstring):
         # b n x1 y1 ... xn yn  Filled B-spline using the given n control points
         tokens = s.split()
         n = int(tokens[0])
-        points = map(int, tokens[1:n * 2 + 1])
+        points = map(float, tokens[1:n * 2 + 1])
         didx = sum(map(len, tokens[1:n * 2 + 1])) + n * 2 + 2
         npoints = nsplit(points, 2)
         return didx, (c, npoints)


### PR DESCRIPTION
It really is an annoying bug :-) It stopped my entire borders of some elements (subgraphs or - I haven't checked yet for that being corrected by the change - nodes) not to be drawn.
