### PR TITLE
fixed crash due to non-existent pyparsing version information

### DIFF
--- a/dot2tex/dot2tex.py
+++ b/dot2tex/dot2tex.py
@@ -2900,10 +2900,8 @@ def main(run_as_module=False, dotdata=None, options=None):
     log.info("Dot2tex version % s" % __version__)
     log.info("System information:\n"
              "  Python: %s \n"
-             "  Platform: %s\n"
-             "  Pyparsing: %s",
-             sys.version_info, platform.platform(),
-             dotparsing.pyparsing_version)
+             "  Platform: %s\n",
+             sys.version_info, platform.platform())
     log.info('dot2tex called with: %s' % sys.argv)
     log.info('Program started in %s' % os.getcwd())
     if not run_as_module:


### PR DESCRIPTION
dot2tex crashes for me with a missing attribute `pyparsing_version`, used only to display pyparsing's version number.
As soon as I remove this, everything works fine.