### PR TITLE
Add the nodes in the subgraphs to get the total number of nodes

### DIFF
--- a/dot2tex/dotparsing.py
+++ b/dot2tex/dotparsing.py
@@ -751,7 +751,7 @@ class DotGraph(object):
         pass
 
     def __len__(self):
-        return len(self._nodes)
+        return len(self._nodes) + sum(len(s) for s in self.subgraphs)
 
     def __getattr__(self, name):
         try:


### PR DESCRIPTION
The `DotGraph.__len__` only tests the nodes that belong to the specific graph, but it needs to also include the nodes of its subgraphs.