### PR TITLE
Use the graph_default_attr to assign it to the graphs.

### DIFF
--- a/dot2tex/dotparsing.py
+++ b/dot2tex/dotparsing.py
@@ -559,6 +559,7 @@ class DotDataParser(object):
                 graph.add_default_graph_attr(**element[1])
                 defattr = DotDefaultAttr('graph', **element[1])
                 graph.allitems.append(defattr)
+                graph.attr.update(**element[1])
             elif cmd == ADD_SUBGRAPH:
                 cmd, name, elements = element
                 # print "Adding subgraph"
@@ -950,6 +951,7 @@ class DotGraph(object):
         subgraphcls.add_default_node_attr(**self.default_node_attr)
         subgraphcls.add_default_edge_attr(**self.default_edge_attr)
         subgraphcls.add_default_graph_attr(**self.attr)
+        subgraphcls.attr.update(self.default_graph_attr)
         subgraphcls.padding += self.padding
         self.subgraphs.append(subgraphcls)
         self._allgraphs.append(subgraphcls)


### PR DESCRIPTION
Currently, the `graph_default_attr` is useless but it is being parsed. We set the `DotGraph.attr` using these values.

This fixes an error with the testsuite with the preamble. When creating a graph with a preample, the second pass of creating a graph in `dot2tex.convert()`, the resulting graph has the option as a `graph_default_attr` (although it was correctly parsed as a `graph_atttr` on the first pass). As such, I believe this fixes #23.