### PR TITLE
update setup.py to install all modules of the dot2tex package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ Graphviz_, a more LaTeX friendly look and feel. This is accomplished by:
       author='Kjell Magne Fauske',
       author_email='kjellmf@gmail.com',
       url="https://github.com/kjellmf/dot2tex",
-      py_modules=['dot2tex.dot2tex', 'dot2tex.dotparsing'],
+      packages=['dot2tex'],
       scripts=['dot2tex/dot2tex'],
       classifiers=[
           'Development Status :: 4 - Beta',


### PR DESCRIPTION
Installing the current version of dot2tex fails to provide a runnable script because of the recent refactoring.

```
% sudo python setup.py install
[...]
% dot2tex
Traceback (most recent call last):
  File "/usr/local/bin/dot2tex", line 11, in <module>
    load_entry_point('dot2tex==2.12.dev0', 'console_scripts', 'dot2tex')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "build/bdist.linux-x86_64/egg/dot2tex/__init__.py", line 35, in <module>
  File "build/bdist.linux-x86_64/egg/dot2tex/dot2tex.py", line 30, in <module>
ImportError: No module named base
```