### PR TITLE
fix error message and tests

### DIFF
--- a/dot2tex/base.py
+++ b/dot2tex/base.py
@@ -182,7 +182,7 @@ def parse_drawstring(drawstring):
                 didx, cmd = doText(c, s[idx + 1:])
                 cmdlist.append(cmd)
         except Exception as err:
-            log.debug("Failed to parse drawstring %s\n%s", s, err.message)
+            log.debug("Failed to parse drawstring %s\n%s", s, str(err))
 
         idx += didx
     return cmdlist, stat

--- a/tests/experimental/test_buildexamples.py
+++ b/tests/experimental/test_buildexamples.py
@@ -119,7 +119,7 @@ def make_img(c, filenm, name):
     if (c.find('--crop') > -1):
         #os.system('del %s.png %s.jpg' % (name,name))
         err = create_pdf(filename)
-        #print "using mppdf"
+        #print("using mppdf")
     else:
         err = meps(filename)
 
@@ -145,7 +145,7 @@ def build_gallery(filelist):
             c = command.replace("dot2tex.py", "dot2tex")
         else:
             c = "dot2tex %s > %s.tex" % (file, name)
-        print c
+        print(c)
 
         err = make_img(c, filename, '')
         if err:
@@ -170,7 +170,7 @@ if __name__ == "__main__":
         log.warning('Failed files: %s', failedfiles);
         sys.exit(1)
     else:
-        print "All tests passed!"
+        print("All tests passed!")
         sys.exit(0)
 
         #filelist=['distances.dot','tikzshapes.dot']

--- a/tests/experimental/test_comparedotparsing.py
+++ b/tests/experimental/test_comparedotparsing.py
@@ -10,7 +10,7 @@ import unittest
 from dot2tex import dotparsing
 import re, os, shutil, glob, sys, time
 
-import ImageChops, Image
+from PIL import ImageChops, Image
 
 from os.path import join, basename, splitext, normpath
 from dot2tex import dotparsing

--- a/tests/experimental/test_graphparsing.py
+++ b/tests/experimental/test_graphparsing.py
@@ -2,7 +2,7 @@
 
 import re, os, shutil, glob, sys, time
 
-import ImageChops, Image
+from PIL import ImageChops, Image
 
 from os.path import join, basename, splitext, normpath
 from dot2tex import dotparsing

--- a/tests/experimental/test_multirender.py
+++ b/tests/experimental/test_multirender.py
@@ -242,7 +242,7 @@ def confirm(prompt=None, resp=False):
         if not ans:
             return resp
         if ans not in ['y', 'Y', 'n', 'N']:
-            print 'please enter y or n.'
+            print('please enter y or n.')
             continue
         if ans == 'y' or ans == 'Y':
             return True
@@ -251,7 +251,7 @@ def confirm(prompt=None, resp=False):
 
 
 def run_rendertest(dotfile):
-    print "Processing %s" % dotfile
+    print("Processing %s" % dotfile)
     err = compare_output(normpath(join(TESTFILES_PATH, dotfile)))
     if err:
         return False
@@ -315,7 +315,7 @@ class RenderTest(unittest.TestCase):
         if sys.platform == 'win32':
             syscmd = "start %s" % 'testrenders.pdf'
             err = runcmd(syscmd)
-        print "Check testrenders.pdf manually"
+        print("Check testrenders.pdf manually")
 
 
 testdotfile2 = normpath(join(TESTFILES_PATH, 'compassports.dot'))


### PR DESCRIPTION
Following changes are incorporated:

- Following python 2.6, most of the Exceptions (such as `ValueError`) have no `message` parameter. Therefore, it is replaced with `str(e)`
- Change print statements according to Python 3 standards.
- Change the import of the packages which are inside PIL (Image, ImageChops)