### PR TITLE
Update usage_guide.rst

### DIFF
--- a/docs/usage_guide.rst
+++ b/docs/usage_guide.rst
@@ -33,7 +33,7 @@ Load ``test.dot``, convert it to xdot format and output the resulting graph usin
 
 The same as above, but use neato for graph layout::
 
-    $ dot2tex --prog=neato -ftikz test.dot > testtikz.tex
+    $ dot2tex --prog=neato -ftikz test.dot > testneato.tex
 
 
 .. admonition:: Invoking dot2tex


### PR DESCRIPTION
for tikz format output file name was testtikz.tex, but for the neato format, it would be more logical to call the output file testneato.tex (testtikz.tex would be misleading here). Or call both test.tex