### PR TITLE
better edge labels for `texmode=raw` and `format=tikz`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist/*
 venv/*
 .idea/*
 
+!*.py

--- a/dot2tex/__main__.py
+++ b/dot2tex/__main__.py
@@ -1,0 +1,4 @@
+from .dot2tex import main
+
+if __name__ == '__main__':
+    main()

--- a/dot2tex/base.py
+++ b/dot2tex/base.py
@@ -386,6 +386,7 @@ class DotConvBase(object):
                 text = drawop[5]
                 # head and tail label
                 texmode = self.options.get('texmode', 'verbatim')
+                label = text = drawobj.attr.get('label', '')
                 if drawobj.attr.get('texmode', ''):
                     texmode = drawobj.attr['texmode']
                 if texlbl_name in drawobj.attr:
@@ -398,6 +399,8 @@ class DotConvBase(object):
                 elif texmode == 'math':
                     # math mode
                     text = "$%s$" % text
+                elif label and len(drawoperations) == 1:
+                    text = label
 
                 drawop[5] = text
                 if self.options.get('alignstr', ''):

--- a/dot2tex/dot2tex.py
+++ b/dot2tex/dot2tex.py
@@ -498,6 +498,3 @@ def convert_graph(dotsource, **kwargs):
     tex = main(True, dotsource, options)
     return tex
 
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
All following discussions assumes `texmode=raw` and `format=tikz`.

Previously, TeX commands (actually the backslashes alone) in edge labels are unconditionally removed in the resulting TeX file. I found this behaviour inconsistent with node labels, where backslashes even need not be escaped to appear in the output. It turns out if label texts go through the `parse_drawstring` process, all backslashes will be removed here:

https://github.com/kjellmf/dot2tex/blob/846e9cb99e3a49c885f547141b55a12bb3e41783/dot2tex/base.py#L163

The node labels are specially handled so that the original attribute `label` is used.

In the comment this issue is discussed and marked as `Todo`s:

https://github.com/kjellmf/dot2tex/blob/846e9cb99e3a49c885f547141b55a12bb3e41783/dot2tex/base.py#L381-L385

I find this problem particularly hard, so I only present a minor patch here: only use the original `label` attribute if this `T` operation is the only one in `drawoperations`. In this special case, I believe it is safe to do so, and it is enough for my use case (and I expect it to work for most use cases).

---

### Minor

I received an the following warning when executing `dot2tex` via `python -m dot2tex.dot2tex`:

> RuntimeWarning: 'dot2tex.dot2tex' found in sys.modules after import of package 'dot2tex', but prior to execution of 'dot2tex.dot2tex'; this may result in unpredictable behaviour
>   warn(RuntimeWarning(msg))

After searching this issue on SO, I made the following change to the entry point of `dot2tex`: I moved the call of `main` in `dot2tex.py` to a new file `__main__.py`. Now to start the program one should use `python -m dot2tex` instead of `python -m dot2tex.dot2tex`. I hope you find this change acceptable; in case you are against this change, I can revert this part from this PR.