### PR TITLE
Fixing errors when parsing multiline outputs of xdotdata

### DIFF
--- a/dot2tex/utils.py
+++ b/dot2tex/utils.py
@@ -83,6 +83,8 @@ def getboolattr(item, key, default):
 
 
 def smart_float(number):
+    if isinstance(number, str):
+        number = number.replace("\\", "").replace("\r", "").replace("\n", "");
     number_as_string = "%s" % float(number)
     if 'e' in number_as_string:
         return "%.4f" % float(number)


### PR DESCRIPTION
On my Windows 10 computer with Graphviz 2.49.1 under ConEmu (not sure if this is relevant) translating a simple dot file via dot2texi:
```
\begin{dot2tex}[dot]
digraph G {
	rankdir=LR;

	closed [label = "Doors closed"];
	open [label = "Doors open"];

	closed -> open [label = "Paid"];
	open -> closed [label = "Passed"];
	closed -> closed [label = "Approached"];
}
\end{dot2tex}
```

Renders the following output from xdotdata:
```
2021-10-17 21:20:59,489 dot2tex DEBUG xdotdata:
b'digraph G {\r\n\tgraph [_draw_="c 9 -#fffffe00 C 7 -#ffffff P 4 0 0 0 71.7 303.48 71.7 303.48 0 ",\r\n\t\tbb="0,0,303.48,71.697",\r\n\t\trankdir=LR,\r\n\t\txdotversion=1.7\r\n\t];\r\n\tnode [label="\\N"];\r\n\tclosed\t[_draw_="c 7 -#000000 e 59.79 20.7 59.59 18 ",\r\n\t\t_ldraw_="F 14 11 -Times-Roman c 7 -#000000 T 59.79 17 0 76 12 -Doors closed ",\r\n\t\theight=0.5,\r\n\t\tlabel="Doors closed",\r\n\t\tpos="59.795,20.697",\r\n\t\twidth=1.661];\r\n\tclosed -> closed\t[_draw_="c 7 -#000000 B 7 42.66 38.11 39.46 47.79 45.17 56.7 59.79 56.7 68.94 56.7 74.59 53.22 76.77 48.24 ",\r\n\t\t_hdraw_="S 5 -solid c 7 -#000000 C 7 -#000000 P 3 80.27 48.16 76.93 38.11 73.28 48.05 ",\r\n\t\t_ldraw_="F 14 11 -Times-Roman c 7 -#000000 T 59.79 60.5 0 70 10 -Approached ",\r\n\t\tlabel=Approached,\r\n\t\tlp="59.795,64.197",\r\n\t\tpos="e,76.933,38.107 42.656,38.107 39.457,47.785 45.17,56.697 59.795,56.697 68.935,56.697 74.595,53.216 76.773,48.242"];\r\n\topen\t[_draw_="c 7 -#000000 e 249.53 20.7 53.89 18 ",\r\n\t\t_ldraw_="F 14 11 -Times-Roman c 7 -#000000 T 249.53 17 0 67 10 -Doors open ",\r\n\t\theight=0.5,\r\n\t\tlabel="Doors open",\r\n\t\tpos="249.53,20.697",\r\n\t\twidth=1.4985];\r\n\tclosed -> open\t[_draw_="c 7 -#000000 B 4 119.68 20.7 140.57 20.7 164.15 20.7 185.38 20.7 ",\r\n\t\t_hdraw_="S 5 -solid c 7 -#000000 C 7 -#000000 P 3 185.58 24.2 195.58 20.7 185.58 17.2 ",\r\n\t\t_ldraw_="F 14 11 -Times-Roman c 7 -#000000 T 157.59 24.5 0 25 4 -Paid ",\r\n\t\tlabel=Paid,\r\n\t\tlp="157.59,28.197",\r\n\t\tpos="e,195.58,20.697 119.68,20.697 140.57,20.697 164.15,20.697 185.38,20.697"];\r\n\topen -> closed\t[_draw_="c 7 -#000000 B 10 209.87 8.38 199.5 5.62 188.21 3.09 177.59 1.7 159.96 -0.62 155.24 -0.45 137.59 1.7 129.54 2.68 121.13 4.22 112.94 \\\r\n6 ",\r\n\t\t_hdraw_="S 5 -solid c 7 -#000000 C 7 -#000000 P 3 112.05 2.61 103.1 8.28 113.64 9.43 ",\r\n\t\t_ldraw_="F 14 11 -Times-Roman c 7 -#000000 T 157.59 5.5 0 40 6 -Passed ",\r\n\t\tlabel=Passed,\r\n\t\tlp="157.59,9.1973",\r\n\t\tpos="e,103.1,8.2833 209.87,8.3842 199.5,5.6207 188.21,3.0947 177.59,1.6973 159.96,-0.62201 155.24,-0.45332 137.59,1.6973 129.54,2.6778 \\\r\n121.13,4.2157 112.94,6.002"];\r\n}\r\n'
```
Which in result fails in dot2tex as following:
```
ERROR    Failed to process input
Traceback (most recent call last):
  File "C:\Python310\lib\site-packages\dot2tex\dot2tex.py", line 3075, in main
    s = conv.convert(dotdata)
  File "C:\Python310\lib\site-packages\dot2tex\dot2tex.py", line 832, in convert
    self.do_edges()
  File "C:\Python310\lib\site-packages\dot2tex\dot2tex.py", line 2266, in do_edges
    s += self.draw_edge(edge)
  File "C:\Python310\lib\site-packages\dot2tex\dot2tex.py", line 2295, in draw_edge
    pp.append("(%sbp,%sbp)" % (smart_float(p[0]), smart_float(p[1])))
  File "C:\Python310\lib\site-packages\dot2tex\dot2tex.py", line 169, in smart_float
    number_as_string = "%s" % float(number)
ValueError: could not convert string to float: '\\\r\n121.13'
```

My PR might be fixing just symptoms of the bigger issue with dot2tex parsing, but at least it unblocks me for now.
Let me know if it would be better to fix it in another place.