### PR TITLE
Fixing more modern graphviz path

### DIFF
--- a/dot2tex/dotparsing.py
+++ b/dot2tex/dotparsing.py
@@ -251,7 +251,7 @@ def find_graphviz():
 
         else:
             # Just in case, try the default...
-            path = r"C:\Program Files\att\Graphviz\bin"
+            path = r"C:\Program Files\Graphviz\bin"
 
         progs = __find_executables(path)
 


### PR DESCRIPTION
From my understanding, Graphviz is no longer installed under att path for last few years at least, and now just sits under `C:\Program Files\Graphviz\bin` directly

Likely register lookup also needs fixing