### PR TITLE
Add support for parallelogram in tikz

### DIFF
--- a/dot2tex/pgfformat.py
+++ b/dot2tex/pgfformat.py
@@ -673,6 +673,7 @@ class Dot2TikZConv(Dot2PGFConv):
                  'trapezium': 'trapezium',
                  'star': 'star',
                  'circle': 'circle',
+                 'parallelogram': 'trapezium, trapezium left angle = 120, trapezium right angle = 60',
                  }
 
     compass_map = {'n': 'north', 'ne': 'north east', 'e': 'east',


### PR DESCRIPTION
Using the dot shape `parallelogram` caused it to be replaced by `ellipse`.

This PR fixes it when using tikz, the generated shape should now be
```
trapezium, trapezium left angle = 120, trapezium right angle = 60
```
Which corresponds to a parallelogram with the slopes from top-left to bottom-right