### PR TITLE
Update pgfformat.py

### DIFF
--- a/dot2tex/pgfformat.py
+++ b/dot2tex/pgfformat.py
@@ -718,7 +718,7 @@ class Dot2TikZConv(Dot2PGFConv):
         s = ""
         if ccolor.startswith('{'):
             # rgb or hsb
-            s += "  \definecolor{%s}%s;\n" % (colorname, ccolor)
+            s += "  \definecolor{%s}%s\n" % (colorname, ccolor)
             cname = colorname
         else:
             cname = color


### PR DESCRIPTION
\definecolor may not end with a `;'.

The extra `';` will trigger a warning in `pdflatex` (or `lualatex`)
> Missing character: There is no ; (U+003B) in font nullfont!

There are four `definecolor` and the other three have no ending `;'.