### PR TITLE
Fix error: attempted relative import with no known parent package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ Graphviz_, a more LaTeX friendly look and feel. This is accomplished by:
           'Topic :: Text Processing :: Markup :: LaTeX',
           'Topic :: Utilities',
       ],
-      install_requires=['pyparsing'],
+      install_requires=['pyparsing', 'setuptools'],
       entry_points={
           'console_scripts': [
               'dot2tex = dot2tex.dot2tex:main',


### PR DESCRIPTION
dot2tex 2.11.3 raise the following error:
```
$ dot2tex 
Traceback (most recent call last):
  File "/tmp/my-project/.venv/bin/dot2tex", line 2, in <module>
    from .dot2tex import main
ImportError: attempted relative import with no known parent package
```

This PR fixes the errror