### PR TITLE
Remove script with same name as entry point

### DIFF
--- a/dot2tex/dot2tex
+++ b/dot2tex/dot2tex
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-from .dot2tex import main
-
-if __name__ == '__main__':
-    main()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ Graphviz_, a more LaTeX friendly look and feel. This is accomplished by:
       author_email='kjellmf@gmail.com',
       url="https://github.com/kjellmf/dot2tex",
       packages=['dot2tex'],
-      scripts=['dot2tex/dot2tex'],
       classifiers=[
           'Development Status :: 4 - Beta',
           'Environment :: Console',


### PR DESCRIPTION
Per https://github.com/pypa/installer/pull/170, the wheel should not have a script with the same name as an entry point. It will lead to two files with the same name being created. I don't think the old script is still needed.