### PR TITLE
Escape string with slash

### DIFF
--- a/dot2tex/base.py
+++ b/dot2tex/base.py
@@ -720,7 +720,7 @@ class DotConvBase(object):
         variables['<<startpreprocsection>>'] = variables['<<endpreprocsection>>'] = ''
         variables['<<startoutputsection>>'] = variables['<<endoutputsection>>'] = ''
         if self.options.get('gvcols'):
-            variables['<<gvcols>>'] = "\input{gvcols.tex}"
+            variables['<<gvcols>>'] = r"\input{gvcols.tex}"
         else:
             variables['<<gvcols>>'] = ""
         self.templatevars = variables


### PR DESCRIPTION
I get following error:
```
E     File "/github/home/.cache/pypoetry/virtualenvs/pyfeyn2-VL5vjsXT-py3.10/lib/python3.10/site-packages/dot2tex/dot2tex.py", line 900
E       variables['<<gvcols>>'] = "\input{gvcols.tex}"
E                                 ^^^^^^^^^^^^^^^^^^^^
E   SyntaxError: invalid escape sequence '\i'
```
This should fix it.