### PR TITLE
Add "texxlbl" node attribute for "xlabel" in TeX format

### DIFF
--- a/dot2tex/base.py
+++ b/dot2tex/base.py
@@ -755,7 +755,7 @@ class DotConvBase(object):
 
         if getattr(drawobj, tex_label_attribute, ''):
             # the texlbl overrides everything
-            text = drawobj.texlbl
+            text = getattr(drawobj, tex_label_attribute)
         elif texmode == 'verbatim':
             # verbatim mode
             text = escape_texchars(text)

--- a/dot2tex/pgfformat.py
+++ b/dot2tex/pgfformat.py
@@ -789,16 +789,16 @@ class Dot2TikZConv(Dot2PGFConv):
             # Quick and dirty introduction of handling for xlabel
             # xlabel = self.get_label(node, label_attribute="xlabel")
             xlabel = None
-            if 'xlabel' in node.attr:
-                #node.attr['texlbl'] = node.attr['xlabel']
-                node.attr['texlbl'] = None
-                xlabel = self.get_label(node,label_attribute="xlabel")
+            if 'xlabel' in node.attr or 'texxlbl' in node.attr:
+                xlabel = self.get_label(node, label_attribute="xlabel", tex_label_attribute="texxlbl")
             #xlabel = node.attr['xlabel'] if 'xlabel' in node.attr else None
             if xlabel is not None:
                 #xlpos = "%sbp,%sbp" % (smart_float(str(float(x)+len(xlabel)*5)), smart_float(y))
                 xlp = getattr(node, 'xlp', None)
                 if not xlp:
-                    continue
+                    # The input file had texxlbl, but had no xlabel,
+                    # so graphviz didn't generate xlp
+                    xlp = x + ',' + 'y'
                 xlpx, xlpy = xlp.split(',')
                 xlpx = str(abs(float(x)-float(xlpx))+float(x))
                 xlpy = y


### PR DESCRIPTION
This would allow to specify a shorter text in the `xlabel`, so that graphviz places it into a more adequate position.

Currently, `texxlbl` without `xlabel` causes xdot to not have xlabel position, so it falls back to the node position. We may want to add an input `xlabel` when it doesn't exist.

Related to: #42 