### PR TITLE
Re-add the pyparsing_version variable to dotparsing.py

### DIFF
--- a/dot2tex/dotparsing.py
+++ b/dot2tex/dotparsing.py
@@ -22,6 +22,7 @@ import pyparsing
 from pyparsing import (Literal, CaselessLiteral, Word, OneOrMore, Forward, Group, Optional, Combine, restOfLine,
                        cStyleComment, nums, alphanums,
                        ParseException, CharsNotIn, Suppress, Regex, removeQuotes)
+from pyparsing import __version__ as pyparsing_version
 
 from collections import OrderedDict
 


### PR DESCRIPTION
Seems like the fix from #47 was reverted at some point - this caused dot2tex to fail on my system with:

```
Traceback (most recent call last):
  File "/opt/homebrew/bin/dot2tex", line 33, in <module>
    sys.exit(load_entry_point('dot2tex==2.12.dev0', 'console_scripts', 'dot2tex')())
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/opt/homebrew/lib/python3.13/site-packages/dot2tex-2.12.dev0-py3.13.egg/dot2tex/dot2tex.py", line 305, in main
    dotparsing.pyparsing_version)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'dot2tex.dotparsing' has no attribute 'pyparsing_version'
```

This fixes the issue 😄 