### PR TITLE
Port to Sphinx 8.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -217,4 +217,4 @@ man_pages = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('http://docs.python.org/', None)}


### PR DESCRIPTION
The old `intersphinx_mapping` format has been removed; it must now map identifiers to (target, inventory) tuples.