### PR TITLE
 Finish modernizing Windows graphviz binary path, broken pgf strings

### DIFF
--- a/dot2tex/base.py
+++ b/dot2tex/base.py
@@ -159,8 +159,8 @@ def parse_drawstring(drawstring):
 
     cmdlist = []
     stat = {}
-    idx = 0
-    s = drawstring #.strip().replace('\\', '')
+    idx = 0   
+    s = drawstring.strip().encode().decode('unicode_escape')
     while idx < len(s) - 1:
         didx = 1
         c = s[idx]
@@ -397,10 +397,11 @@ class DotConvBase(object):
                 # string. Use \\ instead
                 # Todo: Use text from node|edge.label or name
                 # Todo: What about multiline labels?
-                text = drawop[5]
+                label = text = drawop[5]
                 # head and tail label
                 texmode = self.options.get('texmode', 'verbatim')
-                label = text = drawobj.attr.get('label', '')
+                if not is_multiline_label(drawobj):
+                    label = text = drawobj.attr.get('label', '')
                 if drawobj.attr.get('texmode', ''):
                     texmode = drawobj.attr['texmode']
                 if texlbl_name in drawobj.attr:
@@ -820,7 +821,7 @@ class DotConvBase(object):
             if node.attr.get('shape', '') == 'record':
                 log.warning('Record nodes not supported in preprocessing mode: %s', name)
                 continue
-            texlbl = self.get_label(node)
+            texlbl = self.get_label(node).replace("\\\\", "\\")
 
             if texlbl:
                 node.attr['texlbl'] = texlbl

--- a/dot2tex/base.py
+++ b/dot2tex/base.py
@@ -159,7 +159,7 @@ def parse_drawstring(drawstring):
 
     cmdlist = []
     stat = {}
-    idx = 0   
+    idx = 0
     s = drawstring.strip().encode().decode('unicode_escape')
     while idx < len(s) - 1:
         didx = 1
@@ -821,7 +821,7 @@ class DotConvBase(object):
             if node.attr.get('shape', '') == 'record':
                 log.warning('Record nodes not supported in preprocessing mode: %s', name)
                 continue
-            texlbl = self.get_label(node).replace("\\\\", "\\")
+            texlbl = self.get_label(node)
 
             if texlbl:
                 node.attr['texlbl'] = texlbl

--- a/dot2tex/base.py
+++ b/dot2tex/base.py
@@ -45,7 +45,7 @@ def create_xdot(dotdata, prog='dot', options=''):
     progpath = '"%s"' % progs[prog].strip()
     cmd = progpath + ' -T' + output_format + ' ' + options + ' ' + tmp_name
     log.debug('Creating xdot data with: %s', cmd)
-    p = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE, close_fds=(sys.platform != 'win32'))
+    p = Popen(cmd, shell=True, stdout=PIPE, stderr=PIPE, close_fds=(sys.platform != 'win32'), text=True)
     (stdout, stderr) = (p.stdout, p.stderr)
     try:
         data = stdout.read()
@@ -111,7 +111,7 @@ def parse_drawstring(drawstring):
         tokens = s.split()
         n = int(tokens[0])
         points = [float(t) for t in tokens[1:n * 2 + 1]]
-        didx = sum(len(t) for t in tokens[1:n * 2 + 1]) + n * 2 + 2
+        didx = sum(len(t) for t in tokens[1:n * 2 + 1]) + n * 2 + 2 + 1
         npoints = nsplit(points, 2)
         return didx, (c, npoints)
 
@@ -140,7 +140,7 @@ def parse_drawstring(drawstring):
         n = int(tokens[1])
         tmp = len(size) + len(tokens[1]) + 4
         d = s[tmp:tmp + n]
-        didx = len(d) + tmp
+        didx = len(d) + tmp + 1
         return didx, (c, size, d)
 
     def doText(c, s):
@@ -154,13 +154,13 @@ def parse_drawstring(drawstring):
         n = int(tokens[4])
         tmp = sum(len(t) for t in tokens[0:5]) + 7
         text = s[tmp:tmp + n]
-        didx = len(text) + tmp
+        didx = len(text) + tmp + 1
         return didx, [c, x, y, j, w, text]
 
     cmdlist = []
     stat = {}
     idx = 0
-    s = drawstring.strip().replace('\\', '')
+    s = drawstring #.strip().replace('\\', '')
     while idx < len(s) - 1:
         didx = 1
         c = s[idx]

--- a/dot2tex/dotparsing.py
+++ b/dot2tex/dotparsing.py
@@ -248,7 +248,7 @@ def find_graphviz():
             # Note, we could also use the win32api to get this
             # information, but win32api may not be installed.
 
-            path = os.path.join(os.environ['PROGRAMFILES'], 'ATT', 'GraphViz', 'bin')
+            path = os.path.join(os.environ['PROGRAMFILES'], 'GraphViz', 'bin')
 
         else:
             # Just in case, try the default...

--- a/dot2tex/pgfformat.py
+++ b/dot2tex/pgfformat.py
@@ -223,9 +223,9 @@ class Dot2PGFConv(DotConvBase):
                 self.fillcolor = color
                 if ccolor.startswith('{'):
                     # rgb or hsb
-                    s += r"  \definecolor{newcol}%s\n" % ccolor
+                    s += "  \\definecolor{newcol}%s\n" % ccolor
                     ccolor = 'newcol'
-                s += r"  \pgfsetcolor{%s}\n" % ccolor
+                s += "  \\pgfsetcolor{%s}\n" % ccolor
         elif c == 'c':
             # set pen color
             if self.pencolor != color:
@@ -233,9 +233,9 @@ class Dot2PGFConv(DotConvBase):
                 self.color = ''
                 if ccolor.startswith('{'):
                     # rgb or hsb
-                    s += r"  \definecolor{strokecol}%s\n" % ccolor
+                    s += "  \\definecolor{strokecol}%s\n" % ccolor
                     ccolor = 'strokecol'
-                s += r"  \pgfsetstrokecolor{%s}\n" % ccolor
+                s += "  \\pgfsetstrokecolor{%s}\n" % ccolor
                 if opacity is not None:
                     self.stroke_opacity = opacity
                     # Todo: The opacity should probably be set directly when drawing
@@ -250,14 +250,14 @@ class Dot2PGFConv(DotConvBase):
                 self.color = ''
                 if ccolor.startswith('{'):
                     # rgb
-                    s += r"  \definecolor{fillcol}%s\n" % ccolor
+                    s += "  \\definecolor{fillcol}%s\n" % ccolor
                     ccolor = 'fillcol'
-                s += r"  \pgfsetfillcolor{%s}\n" % ccolor
+                s += "  \\pgfsetfillcolor{%s}\n" % ccolor
                 if opacity is not None:
                     self.opacity = opacity
                     # Todo: The opacity should probably be set directly when drawing
                     # The \pgfsetfillcopacity cmd affects text as well
-                    # s += "  \pgfsetfillopacity{%s}\n" % opacity
+                    # s += "  \\pgfsetfillopacity{%s}\n" % opacity
                 else:
                     self.opacity = None
             else:
@@ -354,7 +354,7 @@ class Dot2PGFConv(DotConvBase):
         lblstyle = ",".join([i for i in styles if i])
         if lblstyle:
             lblstyle = '[' + lblstyle + ']'
-        s = r"  \draw (%sbp,%sbp) node%s {%s};\n" % (smart_float(x), smart_float(y), lblstyle, text)
+        s = "  \\draw (%sbp,%sbp) node%s {%s};\n" % (smart_float(x), smart_float(y), lblstyle, text)
         # TODO should opacity be applied here?
         return s
 
@@ -460,12 +460,12 @@ class Dot2PGFConv(DotConvBase):
             src = pp[0]
             dst = pp[-1]
             if topath:
-                s += r"  \draw [%s] %s to[%s]%s %s;\n" % (stylestr, src,
+                s += "  \\draw [%s] %s to[%s]%s %s;\n" % (stylestr, src,
                                                          topath, extra, dst)
             elif not self.options.get('straightedges'):
-                s += r"  \draw [%s] %s ..%s %s;\n" % (stylestr, " .. ".join(pstrs), extra, pp[-1])
+                s += "  \\draw [%s] %s ..%s %s;\n" % (stylestr, " .. ".join(pstrs), extra, pp[-1])
             else:
-                s += r"  \draw [%s] %s --%s %s;\n" % (stylestr, pp[0], extra, pp[-1])
+                s += "  \\draw [%s] %s --%s %s;\n" % (stylestr, pp[0], extra, pp[-1])
 
         return s
 
@@ -736,7 +736,7 @@ class Dot2TikZConv(Dot2PGFConv):
         s = ""
         if ccolor.startswith('{'):
             # rgb or hsb
-            s += r"  \definecolor{%s}%s\n" % (colorname, ccolor)
+            s += "  \\definecolor{%s}%s\n" % (colorname, ccolor)
             cname = colorname
         else:
             cname = color
@@ -953,13 +953,13 @@ class Dot2TikZConv(Dot2PGFConv):
                     extra = " node%s {%s}" % (lblstyle, edgelabel)
 
             if topath:
-                s += r"  \draw [%s] (%s) to[%s]%s (%s);\n" % (stylestr, src,
+                s += "  \\draw [%s] (%s) to[%s]%s (%s);\n" % (stylestr, src,
                                                              topath, extra, dst)
             elif not self.options.get('straightedges'):
-                s += r"  \draw [%s] %s ..%s (%s);\n" % (stylestr,
+                s += "  \\draw [%s] %s ..%s (%s);\n" % (stylestr,
                                                        " .. ".join(pstrs), extra, dst)
             else:
-                s += r"  \draw [%s] (%s) --%s (%s);\n" % (stylestr, src, extra, dst)
+                s += "  \\draw [%s] (%s) --%s (%s);\n" % (stylestr, src, extra, dst)
 
         return s
 


### PR DESCRIPTION
#90 only partially or practically speaking did not fix at all this issue as 'PROGRAMFILES' should actually be present by default in Windows thus 'ATT' would still be used.  In fact the PATH code seems to simply be broken as the fallback should not be needed.  Nonetheless it is inconsistent from the prior fix.  Also many pgf strings with regex use are invalid, and emit a literal '\n' into latex which is an invalid command.