### PR TITLE
Encoding bugs on Windows

### DIFF
--- a/dot2tex/base.py
+++ b/dot2tex/base.py
@@ -41,7 +41,6 @@ def create_xdot(dotdata, prog='dot', options=''):
     else:
         with open(tmp_name, 'w') as f:
             f.write(dotdata)
-
     output_format = 'xdot'
     progpath = '"%s"' % progs[prog].strip()
     cmd = progpath + ' -T' + output_format + ' ' + options + ' ' + tmp_name
@@ -557,7 +556,6 @@ class DotConvBase(object):
                 s += self.do_drawstring(label_string, edge)
                 s += self.do_drawstring(tail_label_string, edge, "tailtexlbl")
                 s += self.do_drawstring(head_label_string, edge, "headtexlbl")
-
         self.body += s
 
     def do_graph(self):

--- a/dot2tex/base.py
+++ b/dot2tex/base.py
@@ -604,7 +604,6 @@ class DotConvBase(object):
 
                 tmpdata = create_xdot(dotdata, self.options.get('prog', 'dot'),
                                       options=self.options.get('progoptions', ''))
-
                 if tmpdata is None or not tmpdata.strip():
                     log.error('Failed to create xdotdata. Is Graphviz installed?')
                     sys.exit(1)

--- a/dot2tex/dot2tex.py
+++ b/dot2tex/dot2tex.py
@@ -446,7 +446,6 @@ def main(run_as_module=False, dotdata=None, options=None):
     try:
         s = conv.convert(dotdata)
         log.debug('Output:\n%s', s)
-
         if options.autosize:
             conv.dopreproc = False
             s = conv.convert(s)

--- a/dot2tex/dot2tex.py
+++ b/dot2tex/dot2tex.py
@@ -445,7 +445,7 @@ def main(run_as_module=False, dotdata=None, options=None):
         sys.exit(1)
     try:
         s = conv.convert(dotdata)
-        log.debug('OutputHIER:\n%s', s)
+        log.debug('Output:\n%s', s)
 
         if options.autosize:
             conv.dopreproc = False

--- a/dot2tex/dot2tex.py
+++ b/dot2tex/dot2tex.py
@@ -253,7 +253,7 @@ def print_version_info():
 
 
 def load_dot_file(filename):
-    with open(filename, 'r') as f:
+    with open(filename, 'r', encoding="utf8") as f:
         dotdata = f.readlines()
     log.info('Data read from %s' % filename)
     return dotdata
@@ -282,14 +282,11 @@ def main(run_as_module=False, dotdata=None, options=None):
         sys.exit(0)
 
     if options.debug:
-        # initialize log handler
-        if run_as_module:
-            pass
-        else:
-            hdlr = logging.FileHandler('dot2tex.log')
-            log.addHandler(hdlr)
-            formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
-            hdlr.setFormatter(formatter)
+        # initalize log handler
+        hdlr = logging.FileHandler('./dot2tex.log',mode='w', encoding='utf-8')
+        log.addHandler(hdlr)
+        formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
+        hdlr.setFormatter(formatter)
         log.setLevel(logging.DEBUG)
         nodebug = False
     else:
@@ -448,13 +445,14 @@ def main(run_as_module=False, dotdata=None, options=None):
         sys.exit(1)
     try:
         s = conv.convert(dotdata)
-        log.debug('Output:\n%s', s)
+        log.debug('OutputHIER:\n%s', s)
+
         if options.autosize:
             conv.dopreproc = False
             s = conv.convert(s)
             log.debug('Output after preprocessing:\n%s', s)
         if options.outputfile:
-            with open(options.outputfile, 'w') as f:
+            with open(options.outputfile, 'w' ,encoding="utf-8") as f:
                 f.write(s)
         else:
             if not run_as_module:

--- a/dot2tex/pgfformat.py
+++ b/dot2tex/pgfformat.py
@@ -858,7 +858,6 @@ class Dot2TikZConv(Dot2PGFConv):
                     sn += "  \\node (%s) at (%s) [%s,%s] {%s};\n" % \
                           (tikzify(node.name), pos, drawstr, shape, label)
             sn += self.end_node(node)
-
             s += sn
         if nodeoptions:
             s += "\\end{scope}\n"

--- a/dot2tex/pgfformat.py
+++ b/dot2tex/pgfformat.py
@@ -858,6 +858,7 @@ class Dot2TikZConv(Dot2PGFConv):
                     sn += "  \\node (%s) at (%s) [%s,%s] {%s};\n" % \
                           (tikzify(node.name), pos, drawstr, shape, label)
             sn += self.end_node(node)
+
             s += sn
         if nodeoptions:
             s += "\\end{scope}\n"


### PR DESCRIPTION
Windows uses ANSI as default. I have specified utf8 in places where the script was failing. And latex writes logs in ANSI on Windows;
MikTeX's latex.exe does not interpret path to temporary files containing a tilde, so i expanded the path;
I removed condition which disables debug if the script is run as a module, i my opinion it is redundant because user can turn debug off through kv argument and unables user to have logs when uses the tool as a module.
I spot errors during preprocessing in latex logs, it turned out that the .tex file was incorrect due to this: 's += r"\end{preview}%\n"'. 

These changes made dot2tex work on Windows 10.